### PR TITLE
fix(filters): buildAttributesString missing quotes rendering issue

### DIFF
--- a/src/twigextensions/PatternlibTwigExtension.php
+++ b/src/twigextensions/PatternlibTwigExtension.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Patternlib plugin for Craft CMS 3.x
  *
@@ -110,7 +111,7 @@ class PatternlibTwigExtension extends AbstractExtension
 
         foreach ($input as $key => $value) {
             if (!empty($key) && !empty($value)) {
-                $res = $res . $key . '=' . $value . ' ';
+                $res = $res . $key . '="' . $value . '" ';
             } elseif (!empty($key)) {
                 $res = $res . $key . ' ';
             }


### PR DESCRIPTION
Refactor the buildAttributeString filter to include quotes around the attribute value to resolve a rendering issue caused by the absence of quotes. Previously, the absence of quotes resulted in an incorrectly interpreted string by the browser, which was not noticed until now. This commit addresses the issue by ensuring that all attribute values are enclosed in quotes.

Example:

In this example buildAttributeString would not return a quoted string:

```php
buildAttributeString([ "data-tracking-title" => "Workshopleiter bei Fork" ]);
```

returns:

```text
data-tracking-title=Workshopleiter bei fork
```

and would therefore incorrectly render as interpreted by the browser:

```html
<div data-tracking-title="Werkstattleiter" bei="" fork=""></div>
```

This bug did not catch out attention until now. Because a single word string
```php
buildAttributeString([ "data-tracking-title" => "Workshopleiter" ]);
```

returns:
```text
data-tracking-title=Workshopleiter
```

and would be interpreted correctly by the browser as:

```html
<div data-tracking-title="Werkstattleiter"></div>
```

This commit:

- adds quotes around the value of the buildAttributeString filter to fix the issue described above.